### PR TITLE
fix: Add missing key in dictionary and insertion of ^^^ in airline

### DIFF
--- a/colors/spaceduck.vim
+++ b/colors/spaceduck.vim
@@ -211,6 +211,10 @@ endif
 " }}}
 
 " Syntax Highlighting {{{
+"
+let s:palette.fg = s:palette.foreground
+let s:palette.bg = s:palette.background
+
 call s:hi('Normal',           s:palette.fg,          s:palette.bg                     )
 call s:hi('ColorColumn',      s:palette.none,        s:palette.cursor                 )
 call s:hi('CursorLine',       s:palette.none,        s:palette.cursor                 )

--- a/colors/spaceduck.vim
+++ b/colors/spaceduck.vim
@@ -248,7 +248,7 @@ call s:hi('SpellLocal',       s:palette.green,       s:palette.none,       'unde
 call s:hi('SpellRare',        s:palette.yellow,      s:palette.none,       'underline')
 
 call s:hi('StatusLine',       s:palette.cursor,      s:palette.foreground, 'reverse'  )
-call s:hi('StatusLineNC',     s:palette.bg,          s:palette.grey,       'reverse'  )
+call s:hi('StatusLineNC',     s:palette.bg,          s:palette.grey,       'NONE'  )
 call s:hi('StatusLineTermNC', s:palette.bg,          s:palette.darkpurple, 'reverse'  )
 call s:hi('TabLine',          s:palette.bg,          s:palette.grey                   )
 


### PR DESCRIPTION
Redefintions of foreground and background were missing