### PR TITLE
Add Vim9 LSP semantic highlights and align vertical split 

### DIFF
--- a/colors/spaceduck.vim
+++ b/colors/spaceduck.vim
@@ -248,13 +248,13 @@ call s:hi('SpellLocal',       s:palette.green,       s:palette.none,       'unde
 call s:hi('SpellRare',        s:palette.yellow,      s:palette.none,       'underline')
 
 call s:hi('StatusLine',       s:palette.cursor,      s:palette.foreground, 'reverse'  )
-call s:hi('StatusLineNC',     s:palette.bg,          s:palette.grey,       'NONE'  )
+call s:hi('StatusLineNC',     s:palette.bg,          s:palette.cursor,     'NONE'     )
 call s:hi('StatusLineTermNC', s:palette.bg,          s:palette.darkpurple, 'reverse'  )
 call s:hi('TabLine',          s:palette.bg,          s:palette.grey                   )
 
 call s:hi('TabLineFill',      s:palette.grey,        s:palette.black                  )
 call s:hi('TabLineSel',       s:palette.lightgrey,   s:palette.background             )
-call s:hi('VertSplit',        s:palette.selection,   s:palette.none                   )
+call s:hi('VertSplit',        s:palette.cursor,      s:palette.cursor                 )
 call s:hi('Visual',           s:palette.none,        s:palette.selection              )
 call s:hi('WarningMsg',       s:palette.orange,      s:palette.background             )
 call s:hi('WildMenu',         s:palette.black,       s:palette.lightgrey              )

--- a/colors/spaceduck.vim
+++ b/colors/spaceduck.vim
@@ -211,6 +211,10 @@ endif
 " }}}
 
 " Syntax Highlighting {{{
+"
+let s:palette.fg = s:palette.foreground
+let s:palette.bg = s:palette.background
+
 call s:hi('Normal',           s:palette.fg,          s:palette.bg                     )
 call s:hi('ColorColumn',      s:palette.none,        s:palette.cursor                 )
 call s:hi('CursorLine',       s:palette.none,        s:palette.cursor                 )

--- a/colors/spaceduck.vim
+++ b/colors/spaceduck.vim
@@ -248,7 +248,7 @@ call s:hi('SpellLocal',       s:palette.green,       s:palette.none,       'unde
 call s:hi('SpellRare',        s:palette.yellow,      s:palette.none,       'underline')
 
 call s:hi('StatusLine',       s:palette.cursor,      s:palette.foreground, 'reverse'  )
-call s:hi('StatusLineNC',     s:palette.bg,          s:palette.grey,       'reverse'  )
+call s:hi('StatusLineNC',     s:palette.bg,          s:palette.grey,       'NONE'  )
 call s:hi('StatusLineTermNC', s:palette.bg,          s:palette.darkpurple, 'reverse'  )
 call s:hi('TabLine',          s:palette.bg,          s:palette.grey                   )
 

--- a/colors/spaceduck.vim
+++ b/colors/spaceduck.vim
@@ -637,19 +637,19 @@ hi! link LspDiagInlineHint          SpaceduckYellow
 hi! link LspDiagVirtualTextHint     SpaceduckYellow
 hi! link LspDiagSignHintText        SpaceduckYellow
 
-hi! link LspSemanticClass           SpaceDuckCyan
-hi! link LspSemanticEnumMember      SpaceduckForeground
+hi! link LspSemanticClass           SpaceDuckMagenta
+hi! link LspSemanticEnumMember      NONE
 hi! link LspSemanticFunction        SpaceDuckGreen
 hi! link LspSemanticMacro           SpaceDuckPurple
 hi! link LspSemanticMethod          SpaceDuckGreen
 hi! link LspSemanticNamespace       SpaceDuckYellow
 hi! link LspSemanticNumber          SpaceDuckYellow
-hi! link LspSemanticOperator        SpaceduckGreen
-hi! link LspSemanticParameter       SpaceduckForeground
-hi! link LspSemanticProperty        SpaceduckForeground
+hi! link LspSemanticOperator        NONE
+hi! link LspSemanticParameter       NONE
+hi! link LspSemanticProperty        NONE
 hi! link LspSemanticStruct          SpaceDuckCyan
 hi! link LspSemanticType            SpaceDuckMagenta
-hi! link LspSemanticVariable        SpaceduckForeground
+hi! link LspSemanticVariable        NONE
 
 " TreeSitter:
 

--- a/colors/spaceduck.vim
+++ b/colors/spaceduck.vim
@@ -623,6 +623,34 @@ hi link CocExplorerHelpLine           SpaceduckMagenta
 
 " }}}
 
+" Vim9 Lsp
+hi! link LspDiagInlineError         SpaceduckRed
+hi! link LspDiagVirtualTextError    SpaceduckRed
+hi! link LspDiagSignErrorText       SpaceduckRed
+hi! link LspDiagInlineWarning       SpaceduckOrange
+hi! link LspDiagVirtualTextWarning  SpaceduckOrange
+hi! link LspDiagSignWarningText     SpaceduckOrange
+hi! link LspDiagInlineInfo          SpaceduckYellow
+hi! link LspDiagVirtualTextInfo     SpaceduckYellow
+hi! link LspDiagSignInfoText        SpaceduckYellow
+hi! link LspDiagInlineHint          SpaceduckYellow
+hi! link LspDiagVirtualTextHint     SpaceduckYellow
+hi! link LspDiagSignHintText        SpaceduckYellow
+
+hi! link LspSemanticClass           SpaceDuckCyan
+hi! link LspSemanticEnumMember      SpaceduckForeground
+hi! link LspSemanticFunction        SpaceDuckGreen
+hi! link LspSemanticMacro           SpaceDuckPurple
+hi! link LspSemanticMethod          SpaceDuckGreen
+hi! link LspSemanticNamespace       SpaceDuckYellow
+hi! link LspSemanticNumber          SpaceDuckYellow
+hi! link LspSemanticOperator        SpaceduckGreen
+hi! link LspSemanticParameter       SpaceduckForeground
+hi! link LspSemanticProperty        SpaceduckForeground
+hi! link LspSemanticStruct          SpaceDuckCyan
+hi! link LspSemanticType            SpaceDuckMagenta
+hi! link LspSemanticVariable        SpaceduckForeground
+
 " TreeSitter:
 
 " TODO: UNTESTED Treesitter

--- a/colors/spaceduck.vim
+++ b/colors/spaceduck.vim
@@ -287,7 +287,7 @@ hi! link Special        SpaceduckLightPurple
 hi! link SpecialChar    SpaceduckOrange
 hi! link SpecialComment Comment
 hi! link Statement      SpaceduckGreen
-hi! link StorageClass   SpaceduckLightPurple
+hi! link StorageClass   SpaceduckPink
 hi! link String         SpaceduckCyan
 hi! link Structure      SpaceduckCyan
 hi! link Tag            SpaceduckLightPurple
@@ -637,12 +637,13 @@ hi! link LspDiagInlineHint          SpaceduckYellow
 hi! link LspDiagVirtualTextHint     SpaceduckYellow
 hi! link LspDiagSignHintText        SpaceduckYellow
 
-hi! link LspSemanticClass           SpaceDuckMagenta
+hi! link LspSemanticClass           SpaceDuckLightPurple
 hi! link LspSemanticEnumMember      NONE
 hi! link LspSemanticFunction        SpaceDuckGreen
 hi! link LspSemanticMacro           SpaceDuckPurple
 hi! link LspSemanticMethod          SpaceDuckGreen
-hi! link LspSemanticNamespace       SpaceDuckYellow
+hi! link LspSemanticModifier        NONE
+hi! link LspSemanticNamespace       NONE
 hi! link LspSemanticNumber          SpaceDuckYellow
 hi! link LspSemanticOperator        NONE
 hi! link LspSemanticParameter       NONE


### PR DESCRIPTION
Adds semantic highlighting for the new vim9 lsp and aligns the color of the vertical split with airline

<img width="1396" height="673" alt="image" src="https://github.com/user-attachments/assets/ac6e304a-2cec-4e27-b299-a37e526a9ebb" />
