### PR TITLE
Add vim9 lsp semantic highlights

### DIFF
--- a/colors/spaceduck.vim
+++ b/colors/spaceduck.vim
@@ -637,6 +637,20 @@ hi! link LspDiagInlineHint          SpaceduckYellow
 hi! link LspDiagVirtualTextHint     SpaceduckYellow
 hi! link LspDiagSignHintText        SpaceduckYellow
 
+hi! link LspSemanticClass           SpaceDuckMagenta
+hi! link LspSemanticEnumMember      NONE
+hi! link LspSemanticFunction        SpaceDuckGreen
+hi! link LspSemanticMacro           SpaceDuckPurple
+hi! link LspSemanticMethod          SpaceDuckGreen
+hi! link LspSemanticNamespace       SpaceDuckYellow
+hi! link LspSemanticNumber          SpaceDuckYellow
+hi! link LspSemanticOperator        NONE
+hi! link LspSemanticParameter       NONE
+hi! link LspSemanticProperty        NONE
+hi! link LspSemanticStruct          SpaceDuckCyan
+hi! link LspSemanticType            SpaceDuckMagenta
+hi! link LspSemanticVariable        NONE
+
 " TreeSitter:
 
 " TODO: UNTESTED Treesitter

--- a/colors/spaceduck.vim
+++ b/colors/spaceduck.vim
@@ -287,7 +287,7 @@ hi! link Special        SpaceduckLightPurple
 hi! link SpecialChar    SpaceduckOrange
 hi! link SpecialComment Comment
 hi! link Statement      SpaceduckGreen
-hi! link StorageClass   SpaceduckLightPurple
+hi! link StorageClass   SpaceduckPink
 hi! link String         SpaceduckCyan
 hi! link Structure      SpaceduckCyan
 hi! link Tag            SpaceduckLightPurple
@@ -637,12 +637,13 @@ hi! link LspDiagInlineHint          SpaceduckYellow
 hi! link LspDiagVirtualTextHint     SpaceduckYellow
 hi! link LspDiagSignHintText        SpaceduckYellow
 
-hi! link LspSemanticClass           SpaceDuckMagenta
+hi! link LspSemanticClass           SpaceDuckLightPurple
 hi! link LspSemanticEnumMember      NONE
 hi! link LspSemanticFunction        SpaceDuckGreen
 hi! link LspSemanticMacro           SpaceDuckPurple
 hi! link LspSemanticMethod          SpaceDuckGreen
-hi! link LspSemanticNamespace       SpaceDuckYellow
+hi! link LspSemanticModifier        NONE
+hi! link LspSemanticNamespace       NONE
 hi! link LspSemanticNumber          SpaceDuckYellow
 hi! link LspSemanticOperator        NONE
 hi! link LspSemanticParameter       NONE


### PR DESCRIPTION
Adds more vim9 lsp highlights. I chose a different color for structs/classes than primitive types and changed the `StorageClass` to `SpaceduckPink` (was still unused), so it is not he same color as the classes. Looks very nice imo

<img width="1005" height="508" alt="image" src="https://github.com/user-attachments/assets/09d58cfa-6d5d-4ab0-a911-b0e2d6e4b1c0" />
